### PR TITLE
Fix ruff test not detecting bad formatting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: chartboost/ruff-action@v1
+    - name: Install poetry
+      run: pipx install poetry
+    - uses: actions/setup-python@v5
+      with:
+        python-version-file: pyproject.toml
+        cache: poetry
+    - name: Install dependencies
+      run: |
+        poetry install
+    - name: Run Ruff tests
+      run: poetry run ruff format --check
 
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,8 +49,10 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install
-    - name: Run Ruff tests
+    - name: Ruff format
       run: poetry run ruff format --check
+    - name: Ruff check
+      run: poetry run ruff check
 
   mypy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The Ruff checker is missing formatting issues at the moment; this PR addresses this bug without altering the newly introduced error, as this should be handled by #23. The unit test failure exists in the development branch and should be considered non-blocking for merging.