### PR TITLE
Feat: Implementing the physical activity thresholding

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -720,6 +720,25 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.3.4"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pydantic_settings-2.3.4-py3-none-any.whl", hash = "sha256:11ad8bacb68a045f00e4f862c7a718c8a9ec766aa8fd4c32e39a0594b207b53a"},
+    {file = "pydantic_settings-2.3.4.tar.gz", hash = "sha256:c5802e3d62b78e82522319bbc9b8f8ffb28ad1c988a99311d04f2a6051fca0a7"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -770,6 +789,20 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pyyaml"
@@ -989,4 +1022,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "06f06241c42be7e955bd3b90c17f81c2a33cd5c85f84fcfab329ec5fb4c1cf15"
+content-hash = "c79334af6d7451720523214756c13c6fda2601c11e4b77633ff24512f5423fb7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ pyarrow = "^15.0.0"
 actfast = "^1.0.0"
 numpy = "^1.24.3"
 pydantic = "^2.7.1"
+pydantic-settings = "^2.3.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/src/wristpy/core/config.py
+++ b/src/wristpy/core/config.py
@@ -1,8 +1,5 @@
 """Configuration module for wristpy."""
 
-import pathlib
-
-import pydantic
 import pydantic_settings
 
 

--- a/src/wristpy/core/config.py
+++ b/src/wristpy/core/config.py
@@ -1,0 +1,14 @@
+"""Configuration module for wristpy."""
+
+import pathlib
+
+import pydantic
+import pydantic_settings
+
+
+class Settings(pydantic_settings.BaseSettings):
+    """Settings for wristpy."""
+
+    LIGHT_THRESHOLD: float = 0.03
+    MODERATE_THRESHOLD: float = 0.1
+    VIGOROUS_THRESHOLD: float = 0.3

--- a/src/wristpy/processing/analytics.py
+++ b/src/wristpy/processing/analytics.py
@@ -347,11 +347,11 @@ class GGIRSleepDetection(AbstractSleepDetector):
 
 def compute_physical_activty_categories(
     enmo_epoch1: models.Measurement,
-    thresholds: Tuple[float, float, float] = [
+    thresholds: Tuple[float, float, float] = (
         LIGHT_THRESHOLD,
         MODERATE_THRESHOLD,
         VIGOROUS_THRESHOLD,
-    ],
+    ),
 ) -> models.Measurement:
     """Compute the physical activity categories based on the ENMO data.
 

--- a/src/wristpy/processing/analytics.py
+++ b/src/wristpy/processing/analytics.py
@@ -8,7 +8,12 @@ from typing import List, Tuple, Union
 import numpy as np
 import polars as pl
 
-from wristpy.core import computations, models
+from wristpy.core import computations, config, models
+
+settings = config.Settings()
+LIGHT_THRESHOLD = settings.LIGHT_THRESHOLD
+MODERATE_THRESHOLD = settings.MODERATE_THRESHOLD
+VIGOROUS_THRESHOLD = settings.VIGOROUS_THRESHOLD
 
 
 @dataclass
@@ -338,3 +343,50 @@ class GGIRSleepDetection(AbstractSleepDetector):
         all_periods.sort()
 
         return all_periods
+
+
+def compute_physical_activty_categories(
+    enmo_epoch1: models.Measurement,
+    thresholds: Tuple[float, float, float] = [
+        LIGHT_THRESHOLD,
+        MODERATE_THRESHOLD,
+        VIGOROUS_THRESHOLD,
+    ],
+) -> models.Measurement:
+    """Compute the physical activity categories based on the ENMO data.
+
+    This function uses the enmo_epoch1 data (5s aggregated data) to compute three
+    physical activity levels, light, moderate, and vigorous.
+
+    Args:
+        enmo_epoch1: The enmo epoch1 data, as physical activity data should be computed
+            on aggregated data.
+        thresholds: The threshold values for the physical activity categories.
+            The default values are
+                [light_threshold, moderate_threshold, vigorous_threshold].
+
+    Returns:
+        A Measurement instance with the physical activity categories,
+        temporal resolution is the same as enmo_epoch1.
+
+    Raises:
+        ValueError: If the threshold values are not ascending order.
+    """
+    if list(thresholds) != sorted(thresholds):
+        raise ValueError("Thresholds must be in ascending order.")
+
+    activity_levels = (
+        (
+            (thresholds[0] < enmo_epoch1.measurements)
+            & (enmo_epoch1.measurements <= thresholds[1])
+        )
+        * 1
+        + (
+            (thresholds[1] < enmo_epoch1.measurements)
+            & (enmo_epoch1.measurements <= thresholds[2])
+        )
+        * 2
+        + (enmo_epoch1.measurements > thresholds[2]) * 3
+    )
+
+    return models.Measurement(measurements=activity_levels, time=enmo_epoch1.time)

--- a/src/wristpy/processing/analytics.py
+++ b/src/wristpy/processing/analytics.py
@@ -356,21 +356,22 @@ def compute_physical_activty_categories(
     """Compute the physical activity categories based on the ENMO data.
 
     This function uses the enmo_epoch1 data (5s aggregated data) to compute three
-    physical activity levels, light, moderate, and vigorous.
+    physical activity levels: light, moderate, and vigorous.
 
     Args:
         enmo_epoch1: The enmo epoch1 data, as physical activity data should be computed
             on aggregated data.
         thresholds: The threshold values for the physical activity categories.
             The default values are
-                [light_threshold, moderate_threshold, vigorous_threshold].
+                (light_threshold, moderate_threshold, vigorous_threshold).
 
     Returns:
-        A Measurement instance with the physical activity categories,
-        temporal resolution is the same as enmo_epoch1.
+        A Measurement instance with the physical activity categories;
+        1 for light, 2 for moderate, 3 for vigorous. 0 represents inactivity.
+        The temporal resolution is the same as enmo_epoch1.
 
     Raises:
-        ValueError: If the threshold values are not ascending order.
+        ValueError: If the threshold values are not in ascending order.
     """
     if list(thresholds) != sorted(thresholds):
         raise ValueError("Thresholds must be in ascending order.")

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -176,3 +176,39 @@ def test_run_sleep_detection(sleep_detection: analytics.GGIRSleepDetection) -> N
 
     assert result == []
     assert isinstance(result, List)
+
+
+def test_physical_activity_thresholds_unsorted() -> None:
+    """Test the physical_activity_thresholds method with unsorted thresholds."""
+    tmp_data = np.array([1, 2, 3])
+    dummy_date = datetime(2024, 5, 2)
+    dummy_datetime_list = [dummy_date + timedelta(seconds=i) for i in range(3)]
+    time = pl.Series("time", dummy_datetime_list)
+    tmp_measurement = models.Measurement(measurements=tmp_data, time=time)
+    thresholds = (3, 2, 1)
+
+    with pytest.raises(ValueError):
+        analytics.compute_physical_activty_categories(tmp_measurement, thresholds)
+
+
+def test_physical_activity_thresholds() -> None:
+    """Test the physical_activity_thresholds method."""
+    tmp_data = np.arange(4)
+    dummy_date = datetime(2024, 5, 2)
+    dummy_datetime_list = [dummy_date + timedelta(seconds=i) for i in range(4)]
+    time = pl.Series("time", dummy_datetime_list)
+    tmp_measurement = models.Measurement(measurements=tmp_data, time=time)
+    thresholds = (0, 1, 2)
+    expected_result = np.array(
+        [
+            0,
+            1,
+            2,
+            3,
+        ]
+    )
+
+    result = analytics.compute_physical_activty_categories(tmp_measurement, thresholds)
+
+    assert np.array_equal(result.measurements, expected_result)
+    assert np.array_equal(result.time, time)


### PR DESCRIPTION
Resolves #55 and Resolves #63
This PR adds the `compute_physical_activty_categories` function to `analyptics.py`. It returns a measurement instance with the labelled types of physical activity (light, moderate, vigorous). 

Added `config.py` to `wristpy/core` to handle the settings for the thresholds. This includes changes to poetry and pyproject due to inclusion of pydantic-settings.