### PR TITLE
Fixes mypy errors in test_models and calibration, closes #75

### DIFF
--- a/src/wristpy/processing/calibration.py
+++ b/src/wristpy/processing/calibration.py
@@ -3,6 +3,8 @@
 import math
 from collections.abc import Generator
 from dataclasses import dataclass
+from datetime import datetime
+from typing import cast
 
 import numpy as np
 import polars as pl
@@ -153,7 +155,9 @@ class Calibration:
             CalibrationError: If the calibration process fails to get below the
                 `min_calibration_error` threshold.
         """
-        data_range = acceleration.time.max() - acceleration.time.min()
+        data_range = cast(datetime, acceleration.time.max()) - cast(
+            datetime, acceleration.time.min()
+        )
         total_hours = math.floor(data_range.total_seconds() / 3600)
 
         if total_hours < self.min_calibration_hours:
@@ -425,7 +429,9 @@ class Calibration:
             sampling rate in Hz.
         """
         sampling_rate = timestamps.len() / round(
-            (timestamps.max() - timestamps.min()).total_seconds()  # type: ignore
+            (
+                cast(datetime, timestamps.max()) - cast(datetime, timestamps.min())
+            ).total_seconds()
         )
 
         return round(sampling_rate)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -43,13 +43,14 @@ def test_watchdata_model() -> None:
 
     watch_data = models.WatchData(acceleration=acceleration, lux=lux, temperature=temp)
 
-    assert np.array_equal(watch_data.acceleration.measurements, accel_data)
-    assert np.array_equal(watch_data.lux.measurements, sensor_data)
-    assert np.array_equal(watch_data.temperature.measurements, sensor_data)
-    assert np.array_equal(
-        watch_data.temperature.time.dt.timestamp().to_numpy(),
-        np.array([1, 2, 3]) * 1000000,
-    )
+    if watch_data.lux is not None:
+        assert np.array_equal(watch_data.lux.measurements, sensor_data)
+    if watch_data.temperature is not None:
+        assert np.array_equal(watch_data.temperature.measurements, sensor_data)
+        assert np.array_equal(
+            watch_data.temperature.time.dt.timestamp().to_numpy(),
+            np.array([1, 2, 3]) * 1000000,
+        )
     assert isinstance(watch_data.battery, type(None))
 
 


### PR DESCRIPTION
previous addition of __init__.py revealed additional mypy errors in calibration and test_models. This PR addresses these attribute errors to fix #75. 