### PR TITLE
Bugfix: Change _find_long_blocks to catch leading edge

### DIFF
--- a/src/wristpy/processing/analytics.py
+++ b/src/wristpy/processing/analytics.py
@@ -253,11 +253,9 @@ class GGIRSleepDetection(AbstractSleepDetector):
             if spt_value:
                 n_ones += 1
                 continue
-            if (not spt_value) & (n_ones >= block_length):
+            elif n_ones >= block_length:
                 sleep_idx_array[spt_array_idx - n_ones : spt_array_idx] = 1
-                n_ones = 0
-            if not spt_value:
-                n_ones = 0
+            n_ones = 0
 
         if n_ones >= block_length:
             sleep_idx_array[-n_ones:] = 1

--- a/src/wristpy/processing/analytics.py
+++ b/src/wristpy/processing/analytics.py
@@ -227,8 +227,12 @@ class GGIRSleepDetection(AbstractSleepDetector):
 
         This function finds the first non-zero in below_threshold array, if there are
         none, we return the initial array.
-        We then iterate over the array and count all the ones between zeros
-        (skipping the first 1), if that value is >= long_block we fill in with ones.
+        We then iterate over the array looking for continuous chunks of 1s that
+        are >= _block_length. We set the value of sleep_idx_array to 1 for those
+        blocks that meet the criteria.
+        For blocks that are < block_length, the value  of sleep_idx_array is set to 0.
+        Finally, there is a check to see if the counter ended on a block of 1s, and if
+        that block is > block_length we set those values to 1.
 
         Args:
             below_threshold: the 5-minute rolling median of the anglez difference

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -20,7 +20,7 @@ def sleep_detection() -> analytics.GGIRSleepDetection:
         dummy_date + datetime.timedelta(seconds=i) for i in range(3600)
     ]
     test_time = pl.Series("time", dummy_datetime_list)
-    anglez = np.random.uniform(-90, 90, size=3600)
+    anglez = np.random.randint(-90, 90, size=3600)
     anglez_measurement = models.Measurement(measurements=anglez, time=test_time)
     return analytics.GGIRSleepDetection(anglez_measurement)
 
@@ -30,8 +30,8 @@ def test_find_long_blocks(
 ) -> None:
     """Test the _find_long_blocks method."""
     block_length = 3
-    below_threshold = np.array([0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0])
-    expected_result = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0])
+    below_threshold = np.array([0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    expected_result = np.array([0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0])
 
     result = sleep_detection._find_long_blocks(below_threshold, block_length)
 
@@ -164,14 +164,11 @@ def test_remove_nonwear_periods_no_overlap() -> None:
 
 def test_spt_window(sleep_detection: analytics.GGIRSleepDetection) -> None:
     """Test the _spt_window method."""
-    half_long_block = 180
     sleep_detection.anglez.measurements = np.zeros(
         len(sleep_detection.anglez.measurements)
     )
     expected_length = int(len(sleep_detection.anglez.measurements) / 5) - 1
     expected_result = np.ones(expected_length)
-    expected_result[0:half_long_block] = 0
-    expected_result[-(half_long_block - 1) :] = 0
 
     result = sleep_detection._spt_window(sleep_detection.anglez)
 

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -30,8 +30,8 @@ def test_find_long_blocks(
 ) -> None:
     """Test the _find_long_blocks method."""
     block_length = 3
-    below_threshold = np.array([0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0])
-    expected_result = np.array([0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    below_threshold = np.array([0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0])
+    expected_result = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0])
 
     result = sleep_detection._find_long_blocks(below_threshold, block_length)
 

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -25,30 +25,15 @@ def sleep_detection() -> analytics.GGIRSleepDetection:
     return analytics.GGIRSleepDetection(anglez_measurement)
 
 
-def test_find_long_blocks(
+def test_fill_false_short_blocks(
     sleep_detection: analytics.GGIRSleepDetection,
 ) -> None:
-    """Test the _find_long_blocks method."""
-    block_length = 3
-    below_threshold = np.array([0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0])
-    expected_result = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0])
-
-    result = sleep_detection._find_long_blocks(below_threshold, block_length)
-
-    assert np.array_equal(
-        result, expected_result
-    ), f"Expected {expected_result}, but got {result}"
-
-
-def test_fill_short_blocks(
-    sleep_detection: analytics.GGIRSleepDetection,
-) -> None:
-    """Test the _fill_short_blocks method."""
+    """Test the _fill_false_short_blocks method."""
     gap_block = 3
-    sleep_idx_array = np.array([0, 0, 0, 1, 1, 0, 0, 1])
-    expected_result = np.array([0, 0, 0, 1, 1, 1, 1, 1])
+    sleep_idx_array = np.array([1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1])
+    expected_result = np.array([1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1])
 
-    result = sleep_detection._fill_short_blocks(sleep_idx_array, gap_block)
+    result = sleep_detection._fill_false_short_blocks(sleep_idx_array, gap_block)
 
     assert np.array_equal(
         result, expected_result

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -25,15 +25,19 @@ def sleep_detection() -> analytics.GGIRSleepDetection:
     return analytics.GGIRSleepDetection(anglez_measurement)
 
 
-def test_fill_false_short_blocks(
+def test_fill_false_blocks(
     sleep_detection: analytics.GGIRSleepDetection,
 ) -> None:
     """Test the _fill_false_short_blocks method."""
     gap_block = 3
-    sleep_idx_array = np.array([1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1])
-    expected_result = np.array([1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1])
+    sleep_idx_array = np.array(
+        [True, False, True, False, False, False, True, True, False, True, False, True]
+    )
+    expected_result = np.array(
+        [True, True, True, False, False, False, True, True, True, True, True, True]
+    )
 
-    result = sleep_detection._fill_false_short_blocks(sleep_idx_array, gap_block)
+    result = sleep_detection._fill_false_blocks(sleep_idx_array, gap_block)
 
     assert np.array_equal(
         result, expected_result


### PR DESCRIPTION
Resolves #90 
Resolves #88 

Changed the `_find_long_blocks` to use single pointer similar to `_fill_short_blocks`, this eliminates the issue that arose with using a centered convolution (center point of convolution kernel instead of leading edge of spt_window detected).

Note the modification to the `test_spt_window` compared to the previous test. We initialize the anglez.measurements to be a random number, this can actually cause the test to fail if the block immediately prior to our 'simulated sleep' looks sufficiently like sleep to create a connected longer window. The edge cases are now tested directly in `test_find_long_blocks`.


----------
Modified _find_long_blocks to use single pointer implementation to find chunks of 1s. Modified tests so that test_find_long_blocks now finds start of 1s in middle and at ending of below_threshold. Modified test_spt_window to simpler implementation to remove odd cases where random num generator of anglez caused unpredictable sleep detection at leading edge