### PR TITLE
fix: remove the requirement for 'time' Series in Measurement to have name 'time'. 

### DIFF
--- a/src/wristpy/core/computations.py
+++ b/src/wristpy/core/computations.py
@@ -116,7 +116,10 @@ def moving_median(
         unaltered.
     """
     measurements_polars_df = pl.concat(
-        [pl.DataFrame(acceleration.measurements), pl.DataFrame(acceleration.time)],
+        [
+            pl.DataFrame(acceleration.measurements),
+            pl.DataFrame({"time": acceleration.time}),
+        ],
         how="horizontal",
     )
     measurements_polars_df = measurements_polars_df.set_sorted("time")

--- a/src/wristpy/core/computations.py
+++ b/src/wristpy/core/computations.py
@@ -1,8 +1,60 @@
 """This module will contain functions to compute statistics on the sensor data."""
 
+from typing import Literal
+
 import polars as pl
 
 from wristpy.core import models
+
+
+def _moving(
+    measurement: models.Measurement,
+    epoch_length: int,
+    aggregation: Literal["mean", "std", "median"],
+    *,
+    centered: bool = False,
+    continuous: bool = False,
+) -> models.Measurement:
+    """Internal handler of rolling window functions.
+
+    Args:
+        measurement: The measurement to apply a rolling function to.
+        epoch_length: Length of the window in seconds.
+        aggregation: Name of the function to apply, either 'mean', 'std', or 'median'.
+        centered: If true, centers the window. Defaults to False.
+        continuous: If true, applies the window to every measurement. If false,
+            groups measurements into chunks of epoch_length. Defaults to False.
+
+    Returns:
+        The measurement with the rolling function applied to it.
+    """
+    if epoch_length <= 0:
+        raise ValueError("Epoch length must be greater than 0")
+
+    window_size = f"{int(epoch_length * 1e9)}ns"
+    if centered:
+        offset = f"{-int((epoch_length // 2 + 1) * 1e9)}ns"
+    else:
+        offset = "0ns"
+
+    if continuous:
+        aggregator = getattr(pl, aggregation)("*").rolling(
+            index_column="time", period=window_size, offset=offset
+        )
+        aggregated_df = (
+            measurement.lazy_frame()
+            .select([aggregator])
+            .with_columns(time=measurement.time)
+        )
+    else:
+        aggregator = getattr(pl.exclude(["time"]).drop_nans(), aggregation)
+        aggregated_df = (
+            measurement.lazy_frame()
+            .group_by_dynamic("time", every=window_size, offset=offset)
+            .agg(aggregator())
+        )
+
+    return models.Measurement.from_data_frame(aggregated_df.collect())
 
 
 def moving_mean(array: models.Measurement, epoch_length: int = 5) -> models.Measurement:
@@ -18,35 +70,7 @@ def moving_mean(array: models.Measurement, epoch_length: int = 5) -> models.Meas
     Raises:
         ValueError: If the epoch length is not an integer or is less than 1.
     """
-    if epoch_length < 1:
-        raise ValueError("Epoch length must be greater than 0")
-
-    window_size_seconds = str(epoch_length) + "s"
-
-    measurement_polars_df = pl.concat(
-        [pl.DataFrame(array.measurements), pl.DataFrame(array.time)], how="horizontal"
-    )
-
-    measurement_polars_df = measurement_polars_df.with_columns(
-        pl.col("time").set_sorted()
-    )
-
-    take_mean_expression = [
-        pl.all().exclude(["time"]).drop_nans().mean(),
-    ]
-
-    measurement_df_mean = measurement_polars_df.group_by_dynamic(
-        index_column="time", every=window_size_seconds
-    ).agg(take_mean_expression)
-
-    measurements_mean_array = measurement_df_mean.drop("time").to_numpy()
-    if array.measurements.ndim == 1:
-        measurements_mean_array = measurements_mean_array.flatten()
-
-    return models.Measurement(
-        measurements=measurements_mean_array,
-        time=measurement_df_mean["time"],
-    )
+    return _moving(array, epoch_length, "mean")
 
 
 def moving_std(array: models.Measurement, epoch_length: int = 5) -> models.Measurement:
@@ -62,78 +86,23 @@ def moving_std(array: models.Measurement, epoch_length: int = 5) -> models.Measu
     Raises:
         ValueError: If the epoch length is less than 1.
     """
-    if epoch_length < 1:
-        raise ValueError("Epoch length must be greater than 0")
-
-    window_size_seconds = str(epoch_length) + "s"
-
-    measurement_polars_df = pl.concat(
-        [pl.DataFrame(array.measurements), pl.DataFrame(array.time)], how="horizontal"
-    )
-
-    measurement_polars_df = measurement_polars_df.with_columns(
-        pl.col("time").set_sorted()
-    )
-
-    take_std_expression = [
-        pl.all().exclude(["time"]).drop_nans().std(),
-    ]
-
-    measurement_df_std = measurement_polars_df.group_by_dynamic(
-        index_column="time", every=window_size_seconds
-    ).agg(take_std_expression)
-
-    measurements_std_array = measurement_df_std.drop("time").to_numpy()
-    if array.measurements.ndim == 1:
-        measurements_std_array = measurements_std_array.flatten()
-
-    return models.Measurement(
-        measurements=measurements_std_array,
-        time=measurement_df_std["time"],
-    )
+    return _moving(array, epoch_length, "std")
 
 
-def moving_median(
-    acceleration: models.Measurement, window_size: int
-) -> models.Measurement:
+def moving_median(array: models.Measurement, epoch_length: int) -> models.Measurement:
     """Applies moving median to acceleration data.
 
     Step size for the window is hard-coded to 1 sample.
 
     Args:
-        acceleration: the three dimensional accelerometer data. A Measurement object,
-        it will have two attributes. 1) measurements, containing the three dimensional
-        accelerometer data in an np.array and 2) time, a pl.Series containing
-        datetime.datetime objects.
-
-        window_size: Size of the moving median window. Window is centered.
-        Measured in seconds.
-
+        array: The Measurement object with the sensor data we want to take the median
+            of.
+        epoch_length: Size of the moving median window. Window is centered.
+            Measured in seconds.
 
     Returns:
         Measurement object with rolling median applied to the measurement data. The
         measurements data will retain it's shape, and the time data will be returned
         unaltered.
     """
-    measurements_polars_df = pl.concat(
-        [
-            pl.DataFrame(acceleration.measurements),
-            pl.DataFrame({"time": acceleration.time}),
-        ],
-        how="horizontal",
-    )
-    measurements_polars_df = measurements_polars_df.set_sorted("time")
-    offset = -((window_size // 2) + 1)
-    offset_str = str(offset) + "s"
-    moving_median_df = measurements_polars_df.select(
-        [
-            pl.median("*").rolling(
-                index_column="time", period=f"{window_size}s", offset=offset_str
-            )
-        ]
-    )
-
-    return models.Measurement(
-        measurements=moving_median_df.drop("time").to_numpy(),
-        time=measurements_polars_df["time"],
-    )
+    return _moving(array, epoch_length, "median", centered=True, continuous=True)

--- a/src/wristpy/core/models.py
+++ b/src/wristpy/core/models.py
@@ -34,7 +34,10 @@ class Measurement(BaseModel):
                 'time'. Other column names should not be relied upon.
         """
         return pl.concat(
-            [pl.LazyFrame(self.measurements), pl.LazyFrame({"time": self.time})],
+            [
+                pl.LazyFrame(self.measurements),
+                pl.LazyFrame({"time": self.time}).set_sorted("time"),
+            ],
             how="horizontal",
         )
 

--- a/src/wristpy/core/models.py
+++ b/src/wristpy/core/models.py
@@ -13,6 +13,31 @@ class Measurement(BaseModel):
     measurements: np.ndarray
     time: pl.Series
 
+    @classmethod
+    def from_data_frame(cls, data_frame: pl.DataFrame) -> "Measurement":
+        """Creates a measurement from a Polars DataFrame.
+
+        Args:
+            data_frame: The Polars DataFrame, must have a time column. All
+                non-time columns will be used as the 'measurements' input.
+        """
+        return Measurement(
+            measurements=data_frame.drop("time").to_numpy().squeeze(),
+            time=data_frame["time"],
+        )
+
+    def lazy_frame(self) -> pl.LazyFrame:
+        """Converts the measurement to a LazyFrame.
+
+        Returns:
+            The Measurement as a LazyFrame. The time property will have column name
+                'time'. Other column names should not be relied upon.
+        """
+        return pl.concat(
+            [pl.LazyFrame(self.measurements), pl.LazyFrame({"time": self.time})],
+            how="horizontal",
+        )
+
     class Config:
         """Config to allow for ndarray as input."""
 

--- a/tests/unit/test_computations.py
+++ b/tests/unit/test_computations.py
@@ -175,7 +175,7 @@ def test_moving_median(window_size: int, expected_output: np.ndarray) -> None:
         measurements=test_matrix, time=dummy_datetime_pl
     )
 
-    test_result = computations.moving_median(test_measurement, window_size=window_size)
+    test_result = computations.moving_median(test_measurement, epoch_length=window_size)
 
     assert test_result.measurements.shape == expected_output.shape, (
         f"measurements array are not the same shape. Expected {expected_output.shape}, "

--- a/tests/unit/test_computations.py
+++ b/tests/unit/test_computations.py
@@ -162,7 +162,7 @@ def test_moving_median(window_size: int, expected_output: np.ndarray) -> None:
     """Testing proper function of moving median function."""
     dummy_date = datetime(2024, 5, 2)
     dummy_datetime_list = [dummy_date + timedelta(seconds=i) for i in range(3)]
-    dummy_datetime_pl = pl.Series("time", dummy_datetime_list)
+    dummy_datetime_pl = pl.Series(dummy_datetime_list)
     test_matrix = np.array(
         [
             [1.0, 2.0, 3.0],


### PR DESCRIPTION
In the current implementation, moving_median works only if the polars Series containing the timepoints already has the "time" name. Since this is not enforced by the Measurement class, it can lead to an error when sorting by time.

This PR updates the moving_median function to ensure that the time column name is always set correctly. 