### PR TITLE
133 directory processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ wristpy /input/file/path.gt3x -o /save/path/file_name.csv -c gradient
 ```
 
 #### Run entire directories:
-```sh 
+```sh
 wristpy /path/to/files/input_dir -o /path/to/files/output_dir -c gradient -O .csv
-``` 
+```
 
 ### Using Wristpy through a python script or notebook:
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,19 @@ pip install wristpy
 ## Quick start
 
 ### Using Wristpy through the command-line:
+#### Run single files:
 ```sh
 wristpy /input/file/path.gt3x -o /save/path/file_name.csv -c gradient
 ```
 
+#### Run entire directories:
+```sh 
+wristpy /path/to/files/input_dir -o /path/to/files/output_dir -c gradient -O .csv
+``` 
+
 ### Using Wristpy through a python script or notebook:
 
+#### Running single files:
 ```Python
 
 from wristpy.core import orchestrator
@@ -72,12 +79,41 @@ results = orchestrator.run(
     calibrator='gradient',  # Choose between 'ggir', 'gradient', or 'none'
 )
 
-#Data availble in results object
+#Data available in results object
 enmo = results.enmo
 anglez = results.anglez
 physical_activity_levels = results.physical_activity_levels
 nonwear_array = results.nonwear_epoch
 sleep_windows = results.sleep_windows_epoch
+```
+#### Running entire directories:
+```Python
+
+from wristpy.core import orchestrator
+
+# Define input file path and output location
+
+input_path = '/path/to/files/input_dir'
+output_path = '/path/to/files/output_dir'
+
+# Run the orchestrator
+# Specify the output file type, support for saving as .csv and .parquet
+results_dict = orchestrator.run(
+    input=input_path,
+    output=output_path,
+    calibrator='gradient',  # Choose between 'ggir', 'gradient', or 'none'
+    output_filetype = '.csv'
+)
+
+
+#Data available in dictionry of results.
+subject1 = results_dict['subject1']
+
+enmo = subject1.enmo
+anglez = subject1.anglez
+physical_activity_levels = subject1.physical_activity_levels
+nonwear_array = subject1.nonwear_epoch
+sleep_windows = subject1.sleep_windows_epoch
 ```
 
 ## References

--- a/docs/wristpy_tutorial.md
+++ b/docs/wristpy_tutorial.md
@@ -30,6 +30,20 @@ results = orchestrator.run(
 ```
 This runs the processing pipeline with all the default arguments, creates an output `.csv` file, and will create a `results` object that contains the various output metrics (namely, enmo, angle-z, physical activity values, non-wear detection, sleep detection).
 
+The orchestrator can also process entire directories. The call to the orchestrator remains largely the same but now output is expected to be a directory and the desired filetype for the saved files **must** be specified:
+
+```python
+from wristpy.core import orchestrator
+
+results = orchestrator.run(
+    input = '/path/to/input/dir',
+    output = '/path/to/output/dir',
+    output_filetype = ".csv"
+)
+```
+
+
+
 We can visualize some of the outputs within the `results` object, directly, with the following scripts:
 
 Plot the ENMO across the entire data set:

--- a/src/wristpy/__main__.py
+++ b/src/wristpy/__main__.py
@@ -1,16 +1,11 @@
 """Main function for wristpy."""
 
-from wristpy.core import cli, orchestrator
+from wristpy.core import cli
 
 
-def run_main() -> orchestrator.Results:
-    """Main entry point to wristpy.
-
-    Returns:
-        A Results object containing enmo, anglez, physical activity levels, nonwear
-        detection, and sleep detection.
-    """
-    return cli.main()
+def run_main() -> None:
+    """Main entry point to wristpy."""
+    cli.main()
 
 
 if __name__ == "__main__":

--- a/src/wristpy/core/cli.py
+++ b/src/wristpy/core/cli.py
@@ -3,7 +3,7 @@
 import argparse
 import logging
 import pathlib
-from typing import List, Optional
+from typing import List, Optional, Tuple, cast
 
 from wristpy.core import config, orchestrator
 
@@ -125,7 +125,7 @@ def main(
     orchestrator.run(
         input=arguments.input,
         output=arguments.output,
-        thresholds=tuple(arguments.thresholds),  # type: ignore
+        thresholds=cast(Tuple[float, float, float], tuple(arguments.thresholds)),
         calibrator=None if arguments.calibrator == "none" else arguments.calibrator,
         epoch_length=None if arguments.epoch_length == 0 else arguments.epoch_length,
         verbosity=log_level,

--- a/src/wristpy/core/cli.py
+++ b/src/wristpy/core/cli.py
@@ -3,7 +3,7 @@
 import argparse
 import logging
 import pathlib
-from typing import List, Optional
+from typing import Generator, List, Optional, Union
 
 from wristpy.core import config, orchestrator
 
@@ -83,7 +83,9 @@ def parse_arguments(args: Optional[List[str]] = None) -> argparse.Namespace:
     return parser.parse_args(args)
 
 
-def main(args: Optional[List[str]] = None) -> orchestrator.Results:
+def main(
+    args: Optional[List[str]] = None,
+) -> None:
     """Runs wristpy orchestrator with command line arguments.
 
     Args:
@@ -120,10 +122,15 @@ def main(args: Optional[List[str]] = None) -> orchestrator.Results:
 
     logger.debug("Running wristpy. arguments given: %s", arguments)
 
-    return orchestrator.run(
+    results = orchestrator.run(
         input=arguments.input,
         output=arguments.output,
-        thresholds=tuple(arguments.thresholds),
+        thresholds=tuple(arguments.thresholds),  # type: ignore
         calibrator=None if arguments.calibrator == "none" else arguments.calibrator,
         epoch_length=None if arguments.epoch_length == 0 else arguments.epoch_length,
+        verbosity=log_level,
     )
+
+    if isinstance(results, Generator):
+        for _ in results:
+            pass

--- a/src/wristpy/core/cli.py
+++ b/src/wristpy/core/cli.py
@@ -3,7 +3,7 @@
 import argparse
 import logging
 import pathlib
-from typing import Generator, List, Optional, Union
+from typing import List, Optional
 
 from wristpy.core import config, orchestrator
 
@@ -122,7 +122,7 @@ def main(
 
     logger.debug("Running wristpy. arguments given: %s", arguments)
 
-    results = orchestrator.run(
+    orchestrator.run(
         input=arguments.input,
         output=arguments.output,
         thresholds=tuple(arguments.thresholds),  # type: ignore
@@ -130,7 +130,3 @@ def main(
         epoch_length=None if arguments.epoch_length == 0 else arguments.epoch_length,
         verbosity=log_level,
     )
-
-    if isinstance(results, Generator):
-        for _ in results:
-            pass

--- a/src/wristpy/core/cli.py
+++ b/src/wristpy/core/cli.py
@@ -36,6 +36,15 @@ def parse_arguments(args: Optional[List[str]] = None) -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "-O",
+        "--output_filetype",
+        type=str,
+        default=None,
+        help="Format for save files when processing directories. "
+        "Leave as None when processing single files.",
+    )
+
+    parser.add_argument(
         "-c",
         "--calibrator",
         type=str,
@@ -129,4 +138,5 @@ def main(
         calibrator=None if arguments.calibrator == "none" else arguments.calibrator,
         epoch_length=None if arguments.epoch_length == 0 else arguments.epoch_length,
         verbosity=log_level,
+        output_filetype=arguments.output_filetype,
     )

--- a/src/wristpy/core/exceptions.py
+++ b/src/wristpy/core/exceptions.py
@@ -40,9 +40,3 @@ class InvalidFileTypeError(LoggedException):
     """Wristpy did not expect this file extension."""
 
     pass
-
-
-class DirectoryNotFoundError(LoggedException):
-    """Output save path not found."""
-
-    pass

--- a/src/wristpy/core/models.py
+++ b/src/wristpy/core/models.py
@@ -135,7 +135,7 @@ class WatchData(BaseModel):
         return v
 
 
-class Results(pydantic.BaseModel):
+class OrchestratorResults(pydantic.BaseModel):
     """Dataclass containing results of orchestrator.run()."""
 
     enmo: Measurement

--- a/src/wristpy/core/models.py
+++ b/src/wristpy/core/models.py
@@ -194,17 +194,3 @@ class Results(pydantic.BaseModel):
                 f"The extension: {output.suffix} is not supported."
                 "Please save the file as .csv or .parquet",
             )
-
-
-class ResultsDictionary(pydantic.BaseModel):
-    """Data class containing dictionary like collection of Results."""
-
-    results: dict[str, Results]
-
-    def add_result(self, file: str, result: Results) -> None:
-        """Add a new result to the results dictionary."""
-        self.results[file] = result
-
-    def get_result(self, file: str) -> Optional[Results]:
-        """Get a result object by it's file name."""
-        return self.results.get(file)

--- a/src/wristpy/core/models.py
+++ b/src/wristpy/core/models.py
@@ -177,18 +177,14 @@ class Results(pydantic.BaseModel):
 
         Args:
             output: the name of the file to be saved, and the directory it will
-            be saved in. Must be a .csv or .parquet file.
+                be saved in. Must be a .csv or .parquet file.
 
         Raises:
             InvalidFileTypeError:If the output file path ends with any extension other
                     than csv or parquet.
-            DirectoryNotFoundError: If the directory for the file to be saved in does
-                not exist.
         """
-        if not output.parent.exists():
-            raise exceptions.DirectoryNotFoundError(
-                f"The directory:{output.parent} does not exist."
-            )
+        output.parent.mkdir(parents=True, exist_ok=True)
+
         if output.suffix not in VALID_FILE_TYPES:
             raise exceptions.InvalidFileTypeError(
                 f"The extension: {output.suffix} is not supported."

--- a/src/wristpy/core/models.py
+++ b/src/wristpy/core/models.py
@@ -136,7 +136,7 @@ class WatchData(BaseModel):
 
 
 class Results(pydantic.BaseModel):
-    """dataclass containing results of orchestrator.run()."""
+    """Dataclass containing results of orchestrator.run()."""
 
     enmo: Measurement
     anglez: Measurement
@@ -154,6 +154,7 @@ class Results(pydantic.BaseModel):
         """
         logger.debug("Saving results.")
         self.validate_output(output=output)
+        output.parent.mkdir(parents=True, exist_ok=True)
 
         results_dataframe = pl.DataFrame(
             {"time": self.enmo.time}
@@ -183,8 +184,6 @@ class Results(pydantic.BaseModel):
             InvalidFileTypeError:If the output file path ends with any extension other
                     than csv or parquet.
         """
-        output.parent.mkdir(parents=True, exist_ok=True)
-
         if output.suffix not in VALID_FILE_TYPES:
             raise exceptions.InvalidFileTypeError(
                 f"The extension: {output.suffix} is not supported."

--- a/src/wristpy/core/models.py
+++ b/src/wristpy/core/models.py
@@ -196,7 +196,7 @@ class Results(pydantic.BaseModel):
             )
 
 
-class BatchedResults(pydantic.BaseModel):
+class ResultsDictionary(pydantic.BaseModel):
     """Data class containing dictionary like collection of Results."""
 
     results: dict[str, Results]

--- a/src/wristpy/core/models.py
+++ b/src/wristpy/core/models.py
@@ -1,10 +1,18 @@
 """Internal data model."""
 
+import pathlib
 from typing import Optional
 
 import numpy as np
 import polars as pl
+import pydantic
 from pydantic import BaseModel, field_validator
+
+from wristpy.core import config, exceptions
+
+VALID_FILE_TYPES = (".csv", ".parquet")
+
+logger = config.get_logger()
 
 
 class Measurement(BaseModel):
@@ -125,3 +133,78 @@ class WatchData(BaseModel):
         if v.measurements.ndim != 2 or v.measurements.shape[1] != 3:
             raise ValueError("acceleration must be a 2D array with 3 columns")
         return v
+
+
+class Results(pydantic.BaseModel):
+    """dataclass containing results of orchestrator.run()."""
+
+    enmo: Measurement
+    anglez: Measurement
+    physical_activity_levels: Measurement
+    nonwear_epoch: Measurement
+    sleep_windows_epoch: Measurement
+
+    def save_results(self, output: pathlib.Path) -> None:
+        """Convert to polars and save the dataframe as a csv or parquet file.
+
+        Args:
+            output: The path and file name of the data to be saved. as either a csv or
+                parquet files.
+
+        """
+        logger.debug("Saving results.")
+        self.validate_output(output=output)
+
+        results_dataframe = pl.DataFrame(
+            {"time": self.enmo.time}
+            | {name: value.measurements for name, value in self}
+        )
+
+        if output.suffix == ".csv":
+            results_dataframe.write_csv(output, separator=",")
+        elif output.suffix == ".parquet":
+            results_dataframe.write_parquet(output)
+        else:
+            raise exceptions.InvalidFileTypeError(
+                f"File type must be one of {VALID_FILE_TYPES}"
+            )
+
+        logger.debug("results saved in: %s", output)
+
+    @classmethod
+    def validate_output(cls, output: pathlib.Path) -> None:
+        """Validates that the output path exists and is a valid format.
+
+        Args:
+            output: the name of the file to be saved, and the directory it will
+            be saved in. Must be a .csv or .parquet file.
+
+        Raises:
+            InvalidFileTypeError:If the output file path ends with any extension other
+                    than csv or parquet.
+            DirectoryNotFoundError: If the directory for the file to be saved in does
+                not exist.
+        """
+        if not output.parent.exists():
+            raise exceptions.DirectoryNotFoundError(
+                f"The directory:{output.parent} does not exist."
+            )
+        if output.suffix not in VALID_FILE_TYPES:
+            raise exceptions.InvalidFileTypeError(
+                f"The extension: {output.suffix} is not supported."
+                "Please save the file as .csv or .parquet",
+            )
+
+
+class BatchedResults(pydantic.BaseModel):
+    """Data class containing dictionary like collection of Results."""
+
+    results: dict[str, Results]
+
+    def add_result(self, file: str, result: Results) -> None:
+        """Add a new result to the results dictionary."""
+        self.results[file] = result
+
+    def get_result(self, file: str) -> Optional[Results]:
+        """Get a result object by it's file name."""
+        return self.results.get(file)

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -121,7 +121,7 @@ def run(
     if output is not None:
         output = pathlib.Path(output)
         if not output.is_dir():
-            raise ValueError(f"Output:{output} is not a directory.")
+            raise ValueError("Output is not a valid directory.")
 
     file_names = [
         file for file in itertools.chain(input.glob("*.gt3x"), input.glob("*.bin"))

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -162,9 +162,6 @@ def run(
             verbosity=verbosity,
         )
 
-    if output is None and output_filetype is not None:
-        raise ValueError("If no output is given, output_filetype must be None.")
-
     return _run_directory(
         input=input,
         output=output,
@@ -224,6 +221,9 @@ def _run_directory(
         output from wrist- and hip-worn monitors. Medicine and Science in Sports and
         Exercise, 46(9), 1816-1824.
     """
+    if output is None and output_filetype is not None:
+        raise ValueError("If no output is given, output_filetype must be None.")
+
     if output is not None:
         if output.is_file():
             raise ValueError(
@@ -243,7 +243,7 @@ def _run_directory(
     results_dict = {}
     for file in file_names:
         output_file_path = (
-            output / pathlib.Path(file.stem).with_suffix(output_filetype)  # type: ignore[arg-type]
+            output / pathlib.Path(file.stem).with_suffix(output_filetype)  # type: ignore[arg-type] # if output is defined, so is output_filetype
             if output
             else None
         )

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -187,7 +187,7 @@ def _run_directory(
     epoch_length: Union[int, None] = 5,
     verbosity: int = logging.WARNING,
     output_filetype: Optional[Literal[".csv", ".parquet"]] = None,
-) -> Union[models.OrchestratorResults, Dict[str, models.OrchestratorResults]]:
+) -> Dict[str, models.OrchestratorResults]:
     """Runs main processing steps for wristpy on  directories.
 
     The run_directory() function will execute the run_file() function on entire
@@ -210,8 +210,8 @@ def _run_directory(
         output_filetype: Specifies the data format for the save files.
 
     Returns:
-        All calculated data in a save ready format as a Results object or as a
-        dictionary of OrchestratorResults objects.
+        All calculated data in a save ready format as a dictionary of
+        OrchestratorResults objects.
 
     Raises:
         ValueError: The output given is not a directory.

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -105,9 +105,9 @@ def run(
     """Runs main processing steps for wristpy on single files, or directories.
 
     The run() function will execute the run_file() function on individual files, or
-    run_directory entire directories. When the input path points to a file, the name of
-    the save file will be taken from the given output path (if any). When the input
-    path points to a directory the output path must be a valid directory as well.
+    run_directory() on entire directories. When the input path points to a file, the
+    name of the save file will be taken from the given output path (if any). When the
+    input path points to a directory the output path must be a valid directory as well.
     Output file names will be derived from original file names in the case of directory
     processing.
 

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -4,7 +4,7 @@ import datetime
 import itertools
 import logging
 import pathlib
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import polars as pl
@@ -101,8 +101,8 @@ def run(
     epoch_length: Union[int, None] = 5,
     verbosity: int = logging.WARNING,
     output_dtype: Literal[".csv", ".parquet"] = ".csv",
-) -> Optional[Union[models.Results, models.ResultsDictionary]]:
-    """Runs main processing steps for wristpy as single files, or dirs."""
+) -> Optional[Union[models.Results, Dict[str, models.Results]]]:
+    """Runs main processing steps for wristpy as single files, or directories."""
     logger.setLevel(verbosity)
 
     input = pathlib.Path(input)
@@ -130,7 +130,7 @@ def run(
     if not file_names:
         raise ValueError(f"Directory {input} contains no .gt3x or .bin files.")
 
-    results_dict = models.ResultsDictionary(results={})
+    results_dict = {}
     for file in file_names:
         output_file_path = (
             output / pathlib.Path(file.stem).with_suffix(output_dtype)
@@ -152,7 +152,7 @@ def run(
                 epoch_length=epoch_length,
                 verbosity=verbosity,
             )
-            results_dict.add_result(file=file.stem, result=result)
+            results_dict[file.stem] = result
         except Exception as e:
             logger.error("Did not run file: %s, Error: %s", file, e)
 

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -3,7 +3,6 @@
 import datetime
 import itertools
 import logging
-import os
 import pathlib
 from typing import Dict, List, Literal, Optional, Tuple, Union
 

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -123,17 +123,18 @@ def run(
         epoch_length: The temporal resolution in seconds, the data will be down sampled
             to. If None is given no down sampling is preformed.
         verbosity: The logging level for the logger.
-        output_filetype: specifies the data format for the save files. Only relevant when
-            processing entire directories, otherwise data type will
-            be inferred from the given file name.
+        output_filetype: Specifies the data format for the save files. Must be None when
+            processing files, must be a valid file type when processing directories.
 
     Returns:
         All calculated data in a save ready format as a Results object or as a
         dictionary of Results objects.
 
     Raises:
+        ValueError: If processing a file and the output_filetype is not None
+        ValueError: If processing a directory and output_filetype is not a valid type.
         ValueError: If processing a directory and the output given is not a directory.
-        ValueError: If the input directory contained no files of a valid file type.
+        FileNotFoundError: If the input directory contained no files of a valid type.
 
 
     References:

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -190,11 +190,10 @@ def _run_directory(
 ) -> Union[models.OrchestratorResults, Dict[str, models.OrchestratorResults]]:
     """Runs main processing steps for wristpy on  directories.
 
-    The run_directory() function will execute the run_file() function on individual files, or on
-    entire directories. When the input path points to a file, the name of the save file
-    will be taken from the given output path (if any). When the input path points to a
-    directory the output path must be a valid directory as well. Output file names will
-    be derived from original file names in the case of directory processing.
+    The run_directory() function will execute the run_file() function on entire
+    directories. The input and output (if any) paths must directories. An
+    output_filetype must be specified if and only if an output is given. Output file
+    names will be derived from input file names.
 
 
     Args:

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -101,7 +101,7 @@ def run(
     epoch_length: Union[int, None] = 5,
     verbosity: int = logging.WARNING,
     output_dtype: Literal[".csv", ".parquet"] = ".csv",
-) -> Optional[Union[models.Results, models.BatchedResults]]:
+) -> Optional[Union[models.Results, models.ResultsDictionary]]:
     """Runs main processing steps for wristpy as single files, or dirs."""
     logger.setLevel(verbosity)
 
@@ -130,7 +130,7 @@ def run(
     if not file_names:
         raise ValueError(f"Directory {input} contains no .gt3x or .bin files.")
 
-    batched_results = models.BatchedResults(results={})
+    results_dict = models.ResultsDictionary(results={})
     for file in file_names:
         output_file_path = (
             output / pathlib.Path(file.stem).with_suffix(output_dtype)
@@ -152,11 +152,11 @@ def run(
                 epoch_length=epoch_length,
                 verbosity=verbosity,
             )
-            batched_results.add_result(file=file.stem, result=result)
+            results_dict.add_result(file=file.stem, result=result)
         except Exception as e:
             logger.error("Did not run file: %s, Error: %s", file, e)
 
-    return batched_results
+    return results_dict
 
 
 def run_file(

--- a/tests/smoke/test_orchestrator_smoke.py
+++ b/tests/smoke/test_orchestrator_smoke.py
@@ -1,6 +1,5 @@
 """Tests the main workflow of wristpy orchestrator."""
 
-import logging
 import pathlib
 
 import pytest
@@ -22,7 +21,7 @@ def test_orchestrator_happy_path(
     results = orchestrator.run_file(input=sample_data_gt3x, output=output_path)
 
     assert output_path.exists()
-    assert isinstance(results, orchestrator.Results)
+    assert isinstance(results, models.Results)
     assert isinstance(results.enmo, models.Measurement)
     assert isinstance(results.anglez, models.Measurement)
     assert isinstance(results.nonwear_epoch, models.Measurement)
@@ -42,7 +41,7 @@ def test_orchestrator_different_epoch(
     )
 
     assert output_path.exists()
-    assert isinstance(results, orchestrator.Results)
+    assert isinstance(results, models.Results)
     assert isinstance(results.enmo, models.Measurement)
     assert isinstance(results.anglez, models.Measurement)
     assert isinstance(results.nonwear_epoch, models.Measurement)

--- a/tests/smoke/test_orchestrator_smoke.py
+++ b/tests/smoke/test_orchestrator_smoke.py
@@ -18,10 +18,10 @@ def test_orchestrator_happy_path(
     """Happy path for orchestrator."""
     output_path = tmp_path / file_name
 
-    results = orchestrator.run_file(input=sample_data_gt3x, output=output_path)
+    results = orchestrator._run_file(input=sample_data_gt3x, output=output_path)
 
     assert output_path.exists()
-    assert isinstance(results, models.Results)
+    assert isinstance(results, models.OrchestratorResults)
     assert isinstance(results.enmo, models.Measurement)
     assert isinstance(results.anglez, models.Measurement)
     assert isinstance(results.nonwear_epoch, models.Measurement)
@@ -36,12 +36,12 @@ def test_orchestrator_different_epoch(
     """Test using none default epoch."""
     output_path = tmp_path / "good_file.csv"
 
-    results = orchestrator.run_file(
+    results = orchestrator._run_file(
         input=sample_data_gt3x, output=output_path, epoch_length=None
     )
 
     assert output_path.exists()
-    assert isinstance(results, models.Results)
+    assert isinstance(results, models.OrchestratorResults)
     assert isinstance(results.enmo, models.Measurement)
     assert isinstance(results.anglez, models.Measurement)
     assert isinstance(results.nonwear_epoch, models.Measurement)

--- a/tests/smoke/test_orchestrator_smoke.py
+++ b/tests/smoke/test_orchestrator_smoke.py
@@ -1,5 +1,6 @@
 """Tests the main workflow of wristpy orchestrator."""
 
+import logging
 import pathlib
 
 import pytest
@@ -11,12 +12,16 @@ from wristpy.core import models, orchestrator
     "file_name", [pathlib.Path("test_output.csv"), pathlib.Path("test_output.parquet")]
 )
 def test_orchestrator_happy_path(
-    file_name: pathlib.Path, tmp_path: pathlib.Path, sample_data_gt3x: pathlib.Path
+    file_name: pathlib.Path,
+    tmp_path: pathlib.Path,
+    sample_data_gt3x: pathlib.Path,
 ) -> None:
     """Happy path for orchestrator."""
-    results = orchestrator.run(input=sample_data_gt3x, output=tmp_path / file_name)
+    output_path = tmp_path / file_name
 
-    assert (tmp_path / file_name).exists()
+    results = orchestrator.run_file(input=sample_data_gt3x, output=output_path)
+
+    assert output_path.exists()
     assert isinstance(results, orchestrator.Results)
     assert isinstance(results.enmo, models.Measurement)
     assert isinstance(results.anglez, models.Measurement)
@@ -26,14 +31,17 @@ def test_orchestrator_happy_path(
 
 
 def test_orchestrator_different_epoch(
-    tmp_path: pathlib.Path, sample_data_gt3x: pathlib.Path
+    tmp_path: pathlib.Path,
+    sample_data_gt3x: pathlib.Path,
 ) -> None:
     """Test using none default epoch."""
-    results = orchestrator.run(
-        input=sample_data_gt3x, output=tmp_path / "good_file.csv", epoch_length=None
+    output_path = tmp_path / "good_file.csv"
+
+    results = orchestrator.run_file(
+        input=sample_data_gt3x, output=output_path, epoch_length=None
     )
 
-    assert (tmp_path / "good_file.csv").exists()
+    assert output_path.exists()
     assert isinstance(results, orchestrator.Results)
     assert isinstance(results.enmo, models.Measurement)
     assert isinstance(results.anglez, models.Measurement)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -68,6 +68,7 @@ def test_main_default(
         calibrator=None,
         epoch_length=5,
         verbosity=logging.WARNING,
+        output_filetype=None,
     )
 
 
@@ -103,6 +104,7 @@ def test_main_with_options(
         calibrator="gradient",
         epoch_length=None,
         verbosity=logging.WARNING,
+        output_filetype=None,
     )
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,6 @@
 """Test the wristpy cli."""
 
+import logging
 import pathlib
 
 import pytest
@@ -66,6 +67,7 @@ def test_main_default(
         thresholds=default_thresholds,
         calibrator=None,
         epoch_length=5,
+        verbosity=logging.WARNING,
     )
 
 
@@ -100,6 +102,7 @@ def test_main_with_options(
         thresholds=(0.1, 1.0, 1.5),
         calibrator="gradient",
         epoch_length=None,
+        verbosity=logging.WARNING,
     )
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -139,7 +139,7 @@ def test_run_dir(tmp_path: pathlib.Path, sample_data_gt3x: pathlib.Path) -> None
     results = orchestrator.run(input=input_dir, output=tmp_path)
 
     assert set(tmp_path.glob("*.csv")) == expected_files
-    assert isinstance(results, models.BatchedResults)
+    assert isinstance(results, models.ResultsDictionary)
 
 
 def test_run_bad_dir(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -110,12 +110,6 @@ def test_validate_output_invalid_file_type(tmp_path: pathlib.Path) -> None:
         models.Results.validate_output(tmp_path / "bad_file.oops")
 
 
-def test_validate_output_invalid_directory() -> None:
-    """Test when a bad extention is given."""
-    with pytest.raises(exceptions.DirectoryNotFoundError):
-        models.Results.validate_output(pathlib.Path("road/to/nowhere/good_file.csv"))
-
-
 def test_run_single_file(
     sample_data_gt3x: pathlib.Path,
     tmp_path: pathlib.Path,

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -139,7 +139,7 @@ def test_run_dir(tmp_path: pathlib.Path, sample_data_gt3x: pathlib.Path) -> None
     results = orchestrator.run(input=input_dir, output=tmp_path)
 
     assert set(tmp_path.glob("*.csv")) == expected_files
-    assert isinstance(results, models.ResultsDictionary)
+    assert isinstance(results, dict)
 
 
 def test_run_bad_dir(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6,6 +6,7 @@ import pathlib
 import numpy as np
 import polars as pl
 import pytest
+import pytest_mock
 
 from wristpy.core import exceptions, models, orchestrator
 from wristpy.processing import analytics
@@ -115,3 +116,21 @@ def test_validate_output_invalid_directory() -> None:
         orchestrator.Results.validate_output(
             pathlib.Path("road/to/nowhere/good_file.csv")
         )
+
+
+def test_run_single_file(
+    mocker: pytest_mock.MockerFixture, sample_data_gt3x: pathlib.Path
+) -> None:
+    """Test run function when pointed at a file."""
+
+
+def test_run_dir(
+    mocker: pytest_mock.MockerFixture, sample_data_gt3x: pathlib.Path
+) -> None:
+    """Test run function when pointed at a directory."""
+
+
+def test_run_bad_dir(
+    mocker: pytest_mock.MockerFixture, sample_data_gt3x: pathlib.Path
+) -> None:
+    """Test run function when input is a directory but output is invalid."""

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -131,14 +131,14 @@ def test_run_single_file(
 def test_run_dir(tmp_path: pathlib.Path, sample_data_gt3x: pathlib.Path) -> None:
     """Test run function when pointed at a directory."""
     input_dir = pathlib.Path(__file__).parent.parent / "sample_data"
-    expected_files = [
+    expected_files = {
         tmp_path / "example_actigraph.csv",
         tmp_path / "example_geneactiv.csv",
-    ]
+    }
 
     results = orchestrator.run(input=input_dir, output=tmp_path)
 
-    assert list(tmp_path.glob("*.csv")) == expected_files
+    assert set(tmp_path.glob("*.csv")) == expected_files
     assert isinstance(results, models.BatchedResults)
 
 
@@ -149,7 +149,5 @@ def test_run_bad_dir(
     input_dir = pathlib.Path(__file__).parent.parent / "sample_data"
     bad_output_dir = sample_data_gt3x
 
-    with pytest.raises(
-        ValueError, match=f"Output:{bad_output_dir} is not a directory."
-    ):
+    with pytest.raises(ValueError, match="Output is not a valid directory."):
         orchestrator.run(input=input_dir, output=bad_output_dir)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -172,7 +172,6 @@ def test_bad_file_type(
 ) -> None:
     """Test run function when output file type is invalid."""
     VALID_FILE_TYPES = (".csv", ".parquet")
-    invalid_file_type = ".zip"
     input_dir = pathlib.Path(__file__).parent.parent / "sample_data"
     expected_message = (
         "Invalid output_filetype: "

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,7 +1,6 @@
 """Test the orchestrator.py module."""
 
 import datetime
-import logging
 import pathlib
 
 import numpy as np
@@ -11,11 +10,6 @@ import pytest_mock
 
 from wristpy.core import exceptions, models, orchestrator
 from wristpy.processing import analytics
-
-DEFAULT_THRESHOLDS = (0.0563, 0.1916, 0.6958)
-DEFAULT_CALIBRATOR = "gradient"
-DEFAULT_EPOCH_LENGTH = 5
-DEFAULT_VERBOSITY = 30
 
 
 @pytest.fixture

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -181,5 +181,7 @@ def test_bad_file_type(
 
     with pytest.raises(ValueError, match=re.escape(expected_message)):
         orchestrator.run(
-            input=input_dir, output=tmp_path, output_filetype=invalid_file_type
+            input=input_dir,
+            output=tmp_path,
+            output_filetype=invalid_file_type,  # type: ignore[arg-type]
         )


### PR DESCRIPTION
Resolves #133. Allows for the run function to be used on single files or directories. The former run() function is now run_file() and run() now calls run_file once in the case of single files or for every valid file in the case of directory inputs. 
The new run() function will still return individual Results objects when returning one file, and a dictionary of Results objects when running entire directories. 