### PR TITLE
203 bug checking version

### DIFF
--- a/src/wristpy/core/cli.py
+++ b/src/wristpy/core/cli.py
@@ -15,6 +15,22 @@ app = typer.Typer(
 )
 
 
+@app.callback(invoke_without_command=True)
+def version_check(
+    version: bool = typer.Option(
+        False,
+        "-V",
+        "--version",
+        help="Check the current version of wristpy and exist.",
+        is_eager=True,
+    ),
+) -> None:
+    """Print current version of wristpy and exit."""
+    if version:
+        typer.echo(f"Wristpy version: {config.get_version()}")
+        raise typer.Exit()
+
+
 class OutputFileType(str, Enum):
     """Valid output file types for saving data."""
 
@@ -52,13 +68,6 @@ class NonwearAlgorithms(str, Enum):
     ggir = "ggir"
     cta = "cta"
     detach = "detach"
-
-
-def version_callback(version: bool):
-    """Check the version independently."""
-    if version:
-        typer.echo(f"Wristpy version: {config.get_version()}")
-        raise typer.Exit()
 
 
 @app.command()
@@ -129,15 +138,6 @@ def main(
         help="Determines the level of verbosity. Use -v for info, -vv for debug. "
         "If -vvv or more, it will be set to debug. "
         "Default for warning.",
-        callback=version_callback,
-    ),
-    version: bool = typer.Option(
-        False,
-        "-V",
-        "--version",
-        help="Show the version and exit.",
-        callback=version_callback,
-        is_eager=True,
     ),
 ) -> None:
     """Run wristpy orchestrator with command line arguments."""

--- a/src/wristpy/core/cli.py
+++ b/src/wristpy/core/cli.py
@@ -54,6 +54,13 @@ class NonwearAlgorithms(str, Enum):
     detach = "detach"
 
 
+def version_callback(version: bool):
+    """Check the version independently."""
+    if version:
+        typer.echo(f"Wristpy version: {config.get_version()}")
+        raise typer.Exit()
+
+
 @app.command()
 def main(
     input: pathlib.Path = typer.Argument(
@@ -122,17 +129,19 @@ def main(
         help="Determines the level of verbosity. Use -v for info, -vv for debug. "
         "If -vvv or more, it will be set to debug. "
         "Default for warning.",
+        callback=version_callback,
     ),
     version: bool = typer.Option(
-        False, "-V", "--version", help="Show the version and exit."
+        False,
+        "-V",
+        "--version",
+        help="Show the version and exit.",
+        callback=version_callback,
+        is_eager=True,
     ),
 ) -> None:
     """Run wristpy orchestrator with command line arguments."""
     from wristpy.core import orchestrator
-
-    if version:
-        typer.echo(f"Wristpy version: {config.get_version()}")
-        raise typer.Exit()
 
     if verbosity == 0:
         log_level = logging.WARNING


### PR DESCRIPTION
This addresses issue #203. The changes made were as follows:

1.  The version option was removed from the main function.
2. The --version/ -V option will be handled using typer's app.callback decorator + the is_eager=True argument.  


This allows the version check to happen and exit without running the main function or validating any other options. 

