### PR TITLE
truncation fix

### DIFF
--- a/src/wristpy/processing/mims.py
+++ b/src/wristpy/processing/mims.py
@@ -685,9 +685,12 @@ def aggregate_mims(
         time=result["time"].cast(pl.Datetime("ns")),
     )
 
+    truncate_threshold = 1e-4 * epoch * sampling_rate
     if truncate:
         aggregated_measure.measurements = np.where(
-            aggregated_measure.measurements <= 0.001, 0, aggregated_measure.measurements
+            aggregated_measure.measurements <= truncate_threshold,
+            0,
+            aggregated_measure.measurements,
         )
 
     return aggregated_measure


### PR DESCRIPTION
This fixes issue #214, a bug where wristpy-mims and the original implimentation of mims seemed to have different cutoff thresholds. 

Previously wristpy had a constant threshold value of 1 * 10^-3, as indicated in the mims paper. Upon closer examination of the original code, it was found that mims actually implements the threshold as the product of the constant value, the sampling rate, and epoch size in seconds, [as shown here](https://github.com/mHealthGroup/MIMSunit/blob/master/R/mims_unit.R#L515).

the wristpy truncation value was changed to match the original implementation. 