### PR TITLE
Feature/Issue 212/Feedback

### DIFF
--- a/docs/wristpy_tutorial.md
+++ b/docs/wristpy_tutorial.md
@@ -33,7 +33,7 @@ results = orchestrator.run(
 This runs the processing pipeline with all the default arguments, creates an output `.csv` file, a `.json` file with the pipeline configuration parameters, and will create a `results` object that contains the various output metrics (namely; the specified physical activity metric, angle-z, physical activity classification values, non-wear status, and sleep status).
 
 
-The orchestrator can also process entire directories. The call to the orchestrator remains largely the same but now output is expected to be a directory and the desired filetype for the saved files **must** be specified:
+The orchestrator can also process entire directories. The call to the orchestrator remains largely the same but now output is expected to be a directory and the desired filetype for the saved files can be specified through the output_filetype arguement(default value is ".csv"):
 
 ```python
 from wristpy.core import orchestrator
@@ -44,6 +44,28 @@ results = orchestrator.run(
     output_filetype = ".csv"
 )
 ```
+
+If users would prefer to process specific files instead of entire directories we recommend looping through a list of file names. The following code snipet will save results objects into a dictionary, and the output files into the desired directory:
+
+```python
+from wristpy.core import orchestrator
+import pathlib 
+
+file_path = pathlib.Path("/path/to/data/")
+output_dir = pathlib.Path("/path/to/save/dir/")
+file_names = [pathlib.Path("file1.gt3x"), pathlib.Path("file2.gt3x"), pathlib.Path("file3.gt3x")]
+results_dict = {}
+
+for file in file_names:
+    input_path = file_path / file
+    output_path = output_dir / file.stem + ".csv"
+    result = orchestrator.run(
+        input = input_path
+        output = output_path
+    )
+    results_dict[file.stem] = result
+```
+
 
 
 

--- a/src/wristpy/core/cli.py
+++ b/src/wristpy/core/cli.py
@@ -74,11 +74,10 @@ def main(
         help="Path where data will be saved. Supports .csv and .parquet formats.",
     ),
     output_filetype: OutputFileType = typer.Option(
-        None,
+        ".csv",
         "-O",
         "--output-filetype",
-        help="Format for save files when processing directories. "
-        "Leave as None when processing single files.",
+        help="Format for save files when processing directories. ",
     ),
     calibrator: Calibrator = typer.Option(
         Calibrator.none,
@@ -150,17 +149,21 @@ def main(
     calibrator_value = None if calibrator == Calibrator.none else calibrator.value
 
     logger.debug("Running wristpy. arguments given: %s", locals())
-    orchestrator.run(
-        input=input,
-        output=output,
-        calibrator=calibrator_value,
-        activity_metric=activity_metric.value,
-        thresholds=None if thresholds is None else thresholds,
-        epoch_length=epoch_length,
-        nonwear_algorithm=nonwear_algorithms,  # type: ignore[arg-type] # Covered by NonwearAlgorithm Enum class
-        verbosity=log_level,
-        output_filetype=output_filetype.value if output_filetype else None,  # type: ignore[arg-type] # Covered by OutputFileType Enum class
-    )
+    try:
+        orchestrator.run(
+            input=input,
+            output=output,
+            calibrator=calibrator_value,
+            activity_metric=activity_metric.value,
+            thresholds=None if thresholds is None else thresholds,
+            epoch_length=epoch_length,
+            nonwear_algorithm=nonwear_algorithms,  # type: ignore[arg-type] # Covered by NonwearAlgorithm Enum class
+            verbosity=log_level,
+            output_filetype=output_filetype.value if output_filetype else None,  # type: ignore[arg-type] # Covered by OutputFileType Enum class
+        )
+    except FileNotFoundError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -33,7 +33,7 @@ def run(
     activity_metric: Literal["enmo", "mad", "ag_count", "mims"] = "enmo",
     nonwear_algorithm: Sequence[Literal["ggir", "cta", "detach"]] = ["ggir"],
     verbosity: int = logging.WARNING,
-    output_filetype: Optional[Literal[".csv", ".parquet"]] = None,
+    output_filetype: Literal[".csv", ".parquet"] = ".csv",
 ) -> Union[writers.OrchestratorResults, Dict[str, writers.OrchestratorResults]]:
     """Runs main processing steps for wristpy on single files, or directories.
 
@@ -59,8 +59,8 @@ def run(
         activity_metric: The metric to be used for physical activity categorization.
         nonwear_algorithm: The algorithm to be used for nonwear detection.
         verbosity: The logging level for the logger.
-        output_filetype: Specifies the data format for the save files. Must be None when
-            processing files, must be a valid file type when processing directories.
+        output_filetype: Specifies the data format for the save files. Only used when
+            processing directories.
 
     Returns:
         All calculated data in a save ready format as a Results object or as a
@@ -69,8 +69,7 @@ def run(
     Raises:
         ValueError: If the physical activity thresholds are not unique or not in
             ascending order.
-        ValueError: If processing a file and the output_filetype is not None
-        ValueError: If output is None but output_filetype is not None.
+
 
     References:
         [1] Hildebrand, M., et al. (2014). Age group comparability of raw accelerometer
@@ -105,13 +104,6 @@ def run(
         raise ValueError(message)
 
     if input.is_file():
-        if output_filetype is not None:
-            raise ValueError(
-                "When processing single files, output_filetype should be None - "
-                "the file type will be determined from the output path."
-            )
-        logger.debug("Input is file, forwarding to run_file with output=%s", output)
-
         return _run_file(
             input=input,
             output=output,
@@ -147,14 +139,13 @@ def _run_directory(
     epoch_length: float = 5,
     nonwear_algorithm: Sequence[Literal["ggir", "cta", "detach"]] = ["ggir"],
     verbosity: int = logging.WARNING,
-    output_filetype: Optional[Literal[".csv", ".parquet"]] = None,
+    output_filetype: Literal[".csv", ".parquet"] = ".csv",
     activity_metric: Literal["enmo", "mad", "ag_count", "mims"] = "enmo",
 ) -> Dict[str, writers.OrchestratorResults]:
     """Runs main processing steps for wristpy on  directories.
 
     The run_directory() function will execute the run_file() function on entire
-    directories. The input and output (if any) paths must directories. An
-    output_filetype must be specified if and only if an output is given. Output file
+    directories. The input and output (if any) paths must directories. Output file
     names will be derived from input file names.
 
 
@@ -192,9 +183,6 @@ def _run_directory(
         Activity: Retrospective Observational Data Analysis Study JMIR Mhealth Uhealth
         2022;10(7):e38077 URL: https://mhealth.jmir.org/2022/7/e38077 DOI: 10.2196/38077
     """
-    if output is None and output_filetype is not None:
-        raise ValueError("If no output is given, output_filetype must be None.")
-
     if output is not None:
         if output.is_file():
             raise ValueError(
@@ -214,7 +202,7 @@ def _run_directory(
     results_dict = {}
     for file in file_names:
         output_file_path = (
-            output / pathlib.Path(file.stem).with_suffix(output_filetype)  # type: ignore[arg-type] # if output is defined, so is output_filetype
+            output / pathlib.Path(file.stem).with_suffix(output_filetype)
             if output
             else None
         )

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -134,23 +134,6 @@ def test_run_single_file_nonwear_options(
     assert isinstance(results, writers.OrchestratorResults)
 
 
-def test_run_single_file_bad_output_filetype(
-    sample_data_gt3x: pathlib.Path,
-    tmp_path: pathlib.Path,
-) -> None:
-    """Testing running a single file."""
-    output_file_path = tmp_path / "file_name.csv"
-
-    with pytest.raises(
-        ValueError,
-        match="When processing single files, output_filetype should be None - "
-        "the file type will be determined from the output path.",
-    ):
-        orchestrator.run(
-            input=sample_data_gt3x, output=output_file_path, output_filetype=".csv"
-        )
-
-
 def test_run_dir(tmp_path: pathlib.Path) -> None:
     """Test run function when pointed at a directory."""
     input_dir = pathlib.Path(__file__).parent.parent / "sample_data"


### PR DESCRIPTION
This PR addresses issue #212. It addresses the three pieces of feedback we received on quality of life improvements. 

### Default file type when running directories.

Output filetype is now ".csv" by default. All errors regarding an output_filetype being provided when it should have been 'None' have been removed. Behavior is otherwise unchanged. 

### Suppressing full traceback on FileNotFoundError

Added a try/except block to the cli, allowing for the simple printing of the error message when FileNotFoundError is raised.

### Allow for the running of multiple files, instead of entire directories.

Introducing this to the orchestrator was found to add a non-trivial level of complexity to the code base, in order to accomodate what is essentially just calling run_file() in a for loop. As a compromise a snippet of boilerplate code was added to the tutorial for less technical users. 