### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Python Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/wristpy/security/code-scanning/3](https://github.com/childmindresearch/wristpy/security/code-scanning/3)

To address this problem, explicit `permissions` blocks should be added to the workflow to restrict the GITHUB_TOKEN to the least privilege required. The best way to do this for maximum clarity and maintainability is to add a `permissions:` block at the root of the workflow YAML, directly under the `name:` entry, so that all jobs inherit the read-only permissions unless otherwise overridden. The minimal recommended setting is `contents: read`, which allows the actions to fetch repository contents but does not permit any write actions.

Only one edit is needed: add a `permissions: contents: read` block at the workflow root, i.e., between the `name` key and the `on:` key in `.github/workflows/test.yaml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
