### PR TITLE
fix/issue 250/relative_path

### DIFF
--- a/src/wristpy/core/orchestrator.py
+++ b/src/wristpy/core/orchestrator.py
@@ -235,7 +235,7 @@ def _run_directory(
         )
         try:
             results_dict[str(file)] = _run_file(
-                input=input / file,
+                input=file,
                 output=output_file_path,
                 thresholds=thresholds,
                 calibrator=calibrator,


### PR DESCRIPTION
This fixes #250 buy changing how _run_directory calls _run_file(). The input will now simply be 'file' as opposed to 'input/file'. 