### PR TITLE
Makefile spacing error

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,11 +17,11 @@ help:
 
 
 clean:
-	 @if [ -z "$(BUILDDIR)" ]; then \
-        echo "Error: BUILDDIR is not set."; \
-        exit 1; \
-    fi
-    rm -rf $(BUILDDIR)/*
+	@if [ -z "$(BUILDDIR)" ]; then \
+		echo "Error: BUILDDIR is not set."; \
+		exit 1; \
+	fi
+	rm -rf $(BUILDDIR)/*
 
 livehtml:
 	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
Incorrect use of spaces instead of tabs in the Makefile was causing the docs build to fail.  This change replaces the spaces with tabs so that the `html` target can be built correctly.
